### PR TITLE
UICR-20: Migrate to item-storage v8.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
       "role-storage": "0.1",
       "locations": "3.0",
       "service-points": "3.0",
-      "item-storage": "7.1"
+      "item-storage": "7.1 8.0"
     },
     "permissionSets": [
       {


### PR DESCRIPTION
The scope of the story is to migrate to the new version of:

### Item-storage:8.0, item-storage-batch-sync:0.2, inventory:10.0
Changes:
1. {{item.status.name}} has restricted to the following values:
* Available
* Awaiting pickup
* Awaiting delivery
* Checked out
* In process
* In transit
* Missing
* On order
* Paged
* Withdrawn
* Declared lost

2. *Item.status* and *item.status.name* are required now, no defaulting available anymore;
3. Array *item.copyNumbers* converted to a single value *copyNumber*;
4. Item.status.date is read-only field now and has date-time formatting now ("yyyy-MM-dd'T'HH:mm:ss.SSS+0000").