### PR TITLE
correctly import `required`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-courses
 
+## 1.2.0 (IN PROGRESS)
+
+* correctly import `requried` via `@folio/stripes/util`.
+
 ## [1.1.7](https://github.com/folio-org/ui-courses/tree/v1.1.7) (2020-05-11)
 [Full Changelog](https://github.com/folio-org/ui-courses/compare/v1.1.6...v1.1.7)
 

--- a/package.json
+++ b/package.json
@@ -135,7 +135,6 @@
   },
   "dependencies": {
     "@folio/plugin-find-user": "^2.0.1",
-    "@folio/stripes-util": "^2.0.0",
     "final-form-set-field-data": "^1.0.2",
     "ky": "^0.19.0",
     "lodash": "^4.17.15",

--- a/src/components/CourseForm/sections/CourseFormInfo.js
+++ b/src/components/CourseForm/sections/CourseFormInfo.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Field } from 'react-final-form';
-import { required } from '@folio/stripes-util';
+import { required } from '@folio/stripes/util';
 import { Col, Row, Select, TextField, TextArea } from '@folio/stripes/components';
 
 export default class CourseFormInfo extends React.Component {

--- a/src/components/InstructorForm.js
+++ b/src/components/InstructorForm.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Field } from 'react-final-form';
-import { required } from '@folio/stripes-util';
+import { required } from '@folio/stripes/util';
 import {
   Button,
   Col,


### PR DESCRIPTION
`stripes-util` exports should be consumed via `@folio/stripes/util` and
a peer-dep on `@folio/stripes` rather than a direct dep on
`@folio/stripes-util`.