### PR TITLE
FOLIO-2682 sonarqube alternative LCOV path

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 buildNPM {
-  publishModDescriptor = 'yes'
-  runLint = 'yes'
+  publishModDescriptor = true
+  runLint = true
   runSonarqube = true
-  runTest = 'yes'
+  runTest = true
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ui-courses
 
-Copyright (C) 2019 The Open Library Foundation
+Copyright (C) 2019-2020 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.


### PR DESCRIPTION
Verify the new alternative path to LCOV info. See [FOLIO-2682](https://issues.folio.org/browse/FOLIO-2682)

And testing Sonarqube on merge to master.