### PR TITLE
FOLIO-2706 Use FQDN .dev.folio.org

### DIFF
--- a/.stripesclirc.js
+++ b/.stripesclirc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  okapi: 'https://folio-snapshot-okapi.aws.indexdata.com',
+  okapi: 'https://folio-snapshot-okapi.dev.folio.org',
   tenant: 'diku',
   NODE_ENV: process.env.NODE_ENV,
 };


### PR DESCRIPTION
This was one lingering file. The others were done in PR #74 

@MikeTaylor The "tapes" still refer to the old now-defunct hostname. Leaving that part to you.