### PR TITLE
UICR-108 update peer-deps for stripes v5 compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-courses
 
+## 3.0.0 IN PROGRESS
+
+* Upgrade to `@folio/stripes` `^5.0`, including `plugin-find-user` `v4`, `react-intl` `v5`, `react-router` `v5`. Fixes UICR-108, UICR-109.
+
 ## [2.0.0](https://github.com/folio-org/ui-courses/tree/v2.0.0) (2020-07-31)
 [Full Changelog](https://github.com/folio-org/ui-courses/compare/v1.1.7...v2.0.0)
 

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     ]
   },
   "dependencies": {
-    "@folio/plugin-find-user": "^3.0.0",
+    "@folio/plugin-find-user": "^4.0.0",
     "final-form-set-field-data": "^1.0.2",
     "ky": "^0.19.0",
     "lodash": "^4.17.15",
@@ -154,7 +154,7 @@
     "react-hot-loader": "^4.3.12"
   },
   "peerDependencies": {
-    "@folio/stripes": "^4.0.0",
+    "@folio/stripes": "^5.0.0",
     "prop-types": "*",
     "react": "*",
     "react-intl": "*",
@@ -165,7 +165,7 @@
   "devDependencies": {
     "@cypress/code-coverage": "^3.8.1",
     "@folio/eslint-config-stripes": "~5.1.0",
-    "@folio/stripes": "^4.0.0",
+    "@folio/stripes": "^5.0.0",
     "@folio/stripes-cli": "^1.18.0",
     "babel-eslint": "^10.1.0",
     "cypress": "^4.9.0",
@@ -173,9 +173,9 @@
     "eslint-plugin-cypress": "^2.11.1",
     "localforage": "^1.7.4",
     "react": "^16.8.6",
-    "react-intl": "^4.5.3",
-    "react-router": "^4.3.1",
-    "react-router-dom": "^4.3.1",
+    "react-intl": "^5.7.0",
+    "react-router": "^5.2.0",
+    "react-router-dom": "^5.2.0",
     "wait-on": "^5.0.1",
     "yakbak-proxy": "^1.5.0"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { hot } from 'react-hot-loader';
-import Switch from 'react-router-dom/Switch';
-import Redirect from 'react-router-dom/Redirect';
+import { Switch, Redirect } from 'react-router-dom';
 import { Route as NestedRoute } from '@folio/stripes/core';
 import Settings from './settings';
 import FullScreenRoute from './routes/FullScreenRoute';


### PR DESCRIPTION
Update peer deps for compatibility with `@folio/stripes` `v5`
compatibility, including `stripes` itself, `react-router` `v5`, and
`react-intl` `v5`.

Refs [UICR-108](https://issues.folio.org/browse/UICR-108), [UICR-109](https://issues.folio.org/browse/UICR-108)