### PR TITLE
UICR-103 avoid clipping Datepicker display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-courses
 
+## 3.1.0 IN PROGRESS
+
+* Render `<Datepicker>` in a portal to avoid CSS clipping. Refs UICR-103.
+
 ## [3.0.0](https://github.com/folio-org/ui-courses/tree/v3.0.0) (2020-10-16)
 [Full Changelog](https://github.com/folio-org/ui-courses/compare/v2.0.0...v3.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for ui-courses
 
-## 3.1.0 IN PROGRESS
+## 3.0.1 IN PROGRESS
 
 * Render `<Datepicker>` in a portal to avoid CSS clipping. Refs UICR-103.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/courses",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Maintain courses and reserve items for them",
   "repository": "https://github.com/folio-org/ui-courses",
   "license": "Apache-2.0",

--- a/src/components/ReserveForm/sections/ReserveFormInfo.js
+++ b/src/components/ReserveForm/sections/ReserveFormInfo.js
@@ -49,6 +49,7 @@ const ReserveFormInfo = (props) => {
                 backendDateStandard="YYYY-MM-DD"
                 label={placeholder}
                 component={Datepicker}
+                usePortal
               />
             )}
           </FormattedMessage>
@@ -63,6 +64,7 @@ const ReserveFormInfo = (props) => {
                 backendDateStandard="YYYY-MM-DD"
                 label={placeholder}
                 component={Datepicker}
+                usePortal
               />
             )}
           </FormattedMessage>

--- a/src/settings/TermSettings.js
+++ b/src/settings/TermSettings.js
@@ -14,6 +14,7 @@ const dateFieldType = ({ fieldProps }) => (
     component={Datepicker}
     marginBottom0
     fullWidth
+    usePortal
   />
 );
 


### PR DESCRIPTION
Pass the `usePortal` prop to `<Datepicker>` to prevent its display from
being clipped when the container window is narrow.

Refs [UICR-103](https://issues.folio.org/browse/UICR-103)