### PR TITLE
UICR-111: Focus Results pane when search has hits

### DIFF
--- a/src/components/CoursesSearchPane.js
+++ b/src/components/CoursesSearchPane.js
@@ -103,7 +103,7 @@ class CoursesSearchPane extends React.Component {
           <FilterNavigation current="courses" />
           <div className={css.searchGroupWrap}>
             <FormattedMessage id="ui-courses.searchInputLabel">
-              { ariaLabel => (
+              { ([ariaLabel]) => (
                 <SearchField
                   data-test-courses-search-input
                   id="input-courses-search"

--- a/src/components/ReservesSearchPane.js
+++ b/src/components/ReservesSearchPane.js
@@ -107,7 +107,7 @@ class ReservesSearchPane extends React.Component {
           <FilterNavigation current="reserves" />
           <div className={css.searchGroupWrap}>
             <FormattedMessage id="ui-courses.searchInputLabel">
-              { ariaLabel => (
+              { ([ariaLabel]) => (
                 <SearchField
                   data-test-reserves-search-input
                   id="input-reserves-search"


### PR DESCRIPTION
Patterned off of [ui-users](https://github.com/folio-org/ui-users/blob/master/src/views/UserSearch/UserSearch.js).

When we're gonna fire off a text search, we set a `searchPending` flag in state so we know that the `source` activity was triggered by a user's search. When that `source` activity settles (isn't `pending`), we manually `.focus()` the pane title via a ref.

(Also nuked an ariaLabel prop-type error while I was looking at the code)