### PR TITLE
Removed plugin-create-inventory-records from deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,6 @@
     ]
   },
   "dependencies": {
-    "@folio/plugin-create-inventory-records": "^2.0.0",
     "@folio/plugin-find-user": "^4.0.0",
     "final-form-set-field-data": "^1.0.2",
     "ky": "^0.23.0",


### PR DESCRIPTION
It should have remained as an optional dep. I think npm autoadded it while I was working on PR #114