### PR TITLE
UICR-116: Removed metadata when viewing course

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Change history for ui-courses
 
-## 4.0.0 (2020-12-16)
+## 4.0.0 (IN PROGRESS)
 
 * Bumped to Stripes platform v6.0.0 and Stripes CLI v2.0.0. Fixes UICR-119.
 * Added ability to Fast Add a reserve. I.e., adding on-the-fly Inventory records as reserves. UICR-91.
 * Bump the maximum number of locations fetched from 500 to 1000. Fixes UICR-120.
+* Added ability to duplicate courses. Fixes UICR-23, UICR-121.
 
 ## [3.1.2](https://github.com/folio-org/ui-courses/tree/v3.1.2) (2020-12-16)
 [Full Changelog](https://github.com/folio-org/ui-courses/compare/v3.1.1...v3.1.2)

--- a/src/components/ViewCourse/sections/ViewCourseData.js
+++ b/src/components/ViewCourse/sections/ViewCourseData.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import get from 'lodash/get';
 import { Card, Col, Row, KeyValue, Tooltip } from '@folio/stripes/components';
-import { ViewMetaData } from '@folio/stripes/smart-components';
 
 const ViewCourseData = ({ record }) => {
   const departmentObject = record.departmentObject || {};
@@ -33,7 +32,6 @@ const ViewCourseData = ({ record }) => {
 
   return (
     <>
-      <ViewMetaData metadata={record.metadata} />
       <Card headerStart={record.name || ''}>
         <Row>
           <Col xs={3}>


### PR DESCRIPTION
Metadata is handled confusingly on our records. It's tracked
separately for `course`, `courseListing`, `instructor`, and `reserve`
records. This means that to get the last time the "Course" was
updated, we need to run through all of that metadata and see
which is latest. Sure, possible, but the final wrinkle is actually
when an instructor or reserve is removed from a courseListing.
In that case, the course or courseListing's metadata are not
updated, so the lastUpdated date can actually _go backwards
in time._ Woof. So, we're backing out this functionality until the
backend changes the way it handles metadata.

The SIG was understandably confused by how everything worked so requested this be backed out in UICR-116.