### PR TITLE
UICR-128: Added ability to view/edit course's numberOfStudents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## IN PROGRESS
 
 * Fix visibility of permissions and canonicalize upper/lower case. Fixes UICR-122 and UICR-123.
+* Added ability to view and edit a course's `numberOfStudents` field. Fixes UICR-128
 
 ## [4.0.0](https://github.com/folio-org/ui-courses/tree/v4.0.0) (2021-03-11)
 

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "@folio/stripes-cli": "^2.0.0",
     "babel-eslint": "^10.1.0",
     "cypress": "^6.4.0",
-    "eslint": "~7.2.0",
+    "eslint": "^6.2.1",
     "eslint-plugin-cypress": "^2.11.1",
     "localforage": "^1.7.4",
     "react": "^16.8.6",

--- a/src/components/CourseForm/sections/CourseFormInfo.js
+++ b/src/components/CourseForm/sections/CourseFormInfo.js
@@ -55,7 +55,7 @@ export default class CourseFormInfo extends React.Component {
               name="courseNumber"
             />
           </Col>
-          <Col xs={3}>
+          <Col xs={4}>
             <Field
               component={TextField}
               id="edit-course-section"
@@ -64,14 +64,33 @@ export default class CourseFormInfo extends React.Component {
               name="sectionName"
             />
           </Col>
-          <Col xs={3}>
+          <Col xs={2}>
             <Field
               component={TextField}
               id="edit-course-number-of-students"
               label={<FormattedMessage id="ui-courses.field.numberOfStudents" />}
               name="numberOfStudents"
-              parse={value => parseInt(value, 10)}
+              parse={value => {
+                if (!value) return undefined;
+
+                // We can't _always_ parse this because the parsed value is the one that gets
+                // checked in our `validate` callback. If we always parsed it, then it'd /already/
+                // be coalesced into an integer if the user entered a float. So if it is a float
+                // we leave it, knowing that it'll fail validation.
+                if (parseInt(value, 10) !== parseFloat(value)) {
+                  return value;
+                }
+
+                return parseInt(value, 10);
+              }}
               type="number"
+              validate={value => {
+                if (value && (parseInt(value, 10) !== parseFloat(value))) {
+                  return <FormattedMessage id="ui-courses.errors.mustBeInteger" />;
+                }
+
+                return undefined;
+              }}
             />
           </Col>
         </Row>

--- a/src/components/CourseForm/sections/CourseFormInfo.js
+++ b/src/components/CourseForm/sections/CourseFormInfo.js
@@ -55,13 +55,23 @@ export default class CourseFormInfo extends React.Component {
               name="courseNumber"
             />
           </Col>
-          <Col xs={6}>
+          <Col xs={3}>
             <Field
               component={TextField}
               id="edit-course-section"
               label={<FormattedMessage id="ui-courses.field.section" />}
               maxLength={255}
               name="sectionName"
+            />
+          </Col>
+          <Col xs={3}>
+            <Field
+              component={TextField}
+              id="edit-course-number-of-students"
+              label={<FormattedMessage id="ui-courses.field.numberOfStudents" />}
+              name="numberOfStudents"
+              parse={value => parseInt(value, 10)}
+              type="number"
             />
           </Col>
         </Row>

--- a/src/components/ViewCourse/sections/ViewCourseData.js
+++ b/src/components/ViewCourse/sections/ViewCourseData.js
@@ -37,7 +37,7 @@ const ViewCourseData = ({ record }) => {
           <Col xs={3}>
             <KeyValue label={<FormattedMessage id="ui-courses.field.name" />} value={courseNameAndDescription} />
           </Col>
-          <Col xs={2}>
+          <Col xs={3}>
             <KeyValue label={<FormattedMessage id="ui-courses.field.department" />} value={departmentNameAndDescription} />
           </Col>
           <Col xs={2}>
@@ -46,7 +46,7 @@ const ViewCourseData = ({ record }) => {
           <Col xs={2}>
             <KeyValue label={<FormattedMessage id="ui-courses.field.section" />} value={record.sectionName} />
           </Col>
-          <Col xs={3}>
+          <Col xs={2}>
             <KeyValue label={<FormattedMessage id="ui-courses.field.numberOfStudents" />} value={record.numberOfStudents ?? <NoValue />} />
           </Col>
         </Row>

--- a/src/components/ViewCourse/sections/ViewCourseData.js
+++ b/src/components/ViewCourse/sections/ViewCourseData.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import get from 'lodash/get';
-import { Card, Col, Row, KeyValue, Tooltip } from '@folio/stripes/components';
+import { Card, Col, Row, KeyValue, NoValue, Tooltip } from '@folio/stripes/components';
 
 const ViewCourseData = ({ record }) => {
   const departmentObject = record.departmentObject || {};
@@ -37,14 +37,17 @@ const ViewCourseData = ({ record }) => {
           <Col xs={3}>
             <KeyValue label={<FormattedMessage id="ui-courses.field.name" />} value={courseNameAndDescription} />
           </Col>
-          <Col xs={3}>
+          <Col xs={2}>
             <KeyValue label={<FormattedMessage id="ui-courses.field.department" />} value={departmentNameAndDescription} />
           </Col>
-          <Col xs={3}>
+          <Col xs={2}>
             <KeyValue label={<FormattedMessage id="ui-courses.field.number" />} value={record.courseNumber} />
           </Col>
-          <Col xs={3}>
+          <Col xs={2}>
             <KeyValue label={<FormattedMessage id="ui-courses.field.section" />} value={record.sectionName} />
+          </Col>
+          <Col xs={3}>
+            <KeyValue label={<FormattedMessage id="ui-courses.field.numberOfStudents" />} value={record.numberOfStudents ?? <NoValue />} />
           </Col>
         </Row>
         <Row>

--- a/translations/ui-courses/en.json
+++ b/translations/ui-courses/en.json
@@ -178,5 +178,6 @@
     "reallyDelete": "Really delete?",
     "addFastAddItem.title": "Add Fast Add item",
     "addFastAddItem.tooltip": "Create a new Inventory record using 'Fast Add' and add it to this course as a reserve",
+    "errors.mustBeInteger": "This value must be an integer",
     "SENTINEL": "SENTINEL"
 }

--- a/translations/ui-courses/en.json
+++ b/translations/ui-courses/en.json
@@ -121,6 +121,7 @@
     "field.totalPagesUsed": "Total number of pages used",
     "field.percentOfPages": "Total % of pages used",
     "field.paymentBasis": "Payment based on",
+    "field.numberOfStudents": "Number of students",
     "create": "New course",
     "crosslist": "Crosslist course",
     "closeEditCourse": "Close edit course",


### PR DESCRIPTION
This uses https://github.com/folio-org/mod-courses/pull/113 to view/edit a course's `numberOfStudents`.

Note i've also popped a tweak to the version of eslint being used. Folio generally uses v6 and having multiple versions available can confuse some package managers so I've bumped it back for workspace-management sanity.