### PR TITLE
UICR-131: Added fallback before parsing if setting isn't defined

### DIFF
--- a/src/settings/DisplaySettings.js
+++ b/src/settings/DisplaySettings.js
@@ -12,7 +12,7 @@ const DisplaySettings = () => (
   <ConfigManager
     configFormComponent={DisplaySettingsForm}
     configName="display"
-    getInitialValues={settings => JSON.parse(settings[0].value)}
+    getInitialValues={settings => JSON.parse(settings[0]?.value ?? '{}')}
     label={<FormattedMessage id="ui-courses.settings.displaySettings" />}
     moduleName="COURSES"
     onBeforeSave={JSON.stringify}


### PR DESCRIPTION
On a new installation, the `.value` doesn't exist yet, so optionally chain into it and null coalesce it into a JSON object if it doesn't exist.