### PR TITLE
UICR-137: Handle term dates that are datetime strings

### DIFF
--- a/src/components/Courses.js
+++ b/src/components/Courses.js
@@ -24,7 +24,7 @@ import CoursesSearchPane from './CoursesSearchPane';
 
 // Returns a date object corresponding with the date string in format YYYY-MM-DD'
 function makeDate(s) {
-  const a = s.split('-');
+  const a = s.split('T')[0].split('-');
   const date = new Date(a[0], a[1] - 1, a[2]); // month is zero-based!
   return date;
 }


### PR DESCRIPTION
Maintain support for date strings, but also support the datetime strings that are created when the UI is used to create terms.