### PR TITLE
UICR-141: Fixed permission gates on routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
         "displayName": "Courses: Read, add, edit, and delete courses",
         "description": "Allows user the ability to fully edit and delete Course Records.",
         "subPermissions": [
-          "ui-courses.read-add-edit",
+          "ui-courses.read-all",
           "course-reserves-storage.courses.item.delete",
           "course-reserves-storage.courselistings.item.delete",
           "course-reserves-storage.courselistings.courses.item.delete",

--- a/src/routes/AddInstructorRoute.js
+++ b/src/routes/AddInstructorRoute.js
@@ -71,7 +71,7 @@ class AddInstructorRoute extends React.Component {
   render() {
     const { handlers, stripes, match } = this.props;
 
-    if (!stripes.hasPerm('course-reserves-storage.courselistings.reserves.item.post')) return <NoPermissions />;
+    if (!stripes.hasPerm('course-reserves-storage.courselistings.instructors.item.post')) return <NoPermissions />;
 
     return (
       <InstructorForm

--- a/src/routes/CreateCourseRoute.js
+++ b/src/routes/CreateCourseRoute.js
@@ -90,7 +90,7 @@ class CreateCourseRoute extends React.Component {
   render() {
     const { handlers, stripes, intl } = this.props;
 
-    if (!stripes.hasPerm('course-reserves-storage.reserves.write')) return <NoPermissions />;
+    if (!stripes.hasPerm('course-reserves-storage.courses.item.post')) return <NoPermissions />;
 
     return (
       <CourseForm

--- a/src/routes/CrosslistCourseRoute.js
+++ b/src/routes/CrosslistCourseRoute.js
@@ -100,7 +100,7 @@ class CrosslistCourseRoute extends React.Component {
   render() {
     const { handlers, stripes, intl } = this.props;
 
-    if (!stripes.hasPerm('course-reserves-storage.reserves.write')) return <NoPermissions />;
+    if (!stripes.hasPerm('course-reserves-storage.courses.item.post')) return <NoPermissions />;
 
     return (
       <CourseForm

--- a/src/routes/EditCourseRoute.js
+++ b/src/routes/EditCourseRoute.js
@@ -121,7 +121,7 @@ class EditCourseRoute extends React.Component {
     const { allCoursesInListing } = this.props.resources;
     const query = queryString.parse(location.search);
 
-    if (!stripes.hasPerm('course-reserves-storage.reserves.write')) return <NoPermissions />;
+    if (!stripes.hasPerm('course-reserves-storage.courses.item.put')) return <NoPermissions />;
 
     // Note: TOO MUCH MAGIC here. We pass `onSubmit`, which is not
     // used by <CourseForm>. It _is_ used by react-final-form's

--- a/src/routes/EditInstructorRoute.js
+++ b/src/routes/EditInstructorRoute.js
@@ -77,7 +77,7 @@ class AddInstructorRoute extends React.Component {
   render() {
     const { handlers, stripes } = this.props;
 
-    if (!stripes.hasPerm('course-reserves-storage.courselistings.reserves.item.put')) return <NoPermissions />;
+    if (!stripes.hasPerm('course-reserves-storage.courselistings.instructors.item.put')) return <NoPermissions />;
 
     return (
       <InstructorForm


### PR DESCRIPTION
This tweaks the perm checks that are done in route handlers. https://github.com/folio-org/ui-courses/pull/141 broke up the perm sets so `.write` is no longer an effective perm to use for gating access to these routes.

Additionally, the instructor form routes appeared to be checking an unrelated permission so I changed them to check the instructor mutation permissions instead.