### PR TITLE
UICR-138: Add item-storage 9.0 optimistic locking dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
       "copyright-status-storage": "0.1",
       "role-storage": "0.1",
       "locations": "3.0",
-      "item-storage": "7.1 8.0",
+      "item-storage": "7.1 8.0 9.0",
       "loan-types": "2.2"
     },
     "permissionSets": [


### PR DESCRIPTION
Add the item-storage 9.0 dependency for optimistic locking.

No code change is needed because ui-courses doesn't directly
PUT to item-storage, it calls
/coursereserves/courselistings/{listing_id}/reserves/{reserve_id}
that does the job.

ui-courses GETs item-storage/items/:{itemId} but this is used
for display only and the new `_version` property is not used
and doesn't affect ui-courses.