### PR TITLE
UICR-92: Removed dependency on redux-form

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,8 +205,7 @@
     "react-intl": "*",
     "react-query": "^3.12.0",
     "react-router": "*",
-    "react-router-dom": "*",
-    "redux-form": "*"
+    "react-router-dom": "*"
   },
   "devDependencies": {
     "@cypress/code-coverage": "^3.9.2",

--- a/src/settings/TermSettings.js
+++ b/src/settings/TermSettings.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
-import { Field, reduxForm } from 'redux-form';
+import { Field } from 'react-final-form';
 import { ControlledVocab } from '@folio/stripes/smart-components';
 import { withStripes } from '@folio/stripes/core';
 import { Datepicker } from '@folio/stripes/components';
@@ -44,6 +44,7 @@ class TermSettings extends React.Component {
 
     return (
       <this.connectedControlledVocab
+        formType="final-form"
         stripes={stripes}
         baseUrl="coursereserves/terms"
         records="terms"
@@ -69,6 +70,4 @@ class TermSettings extends React.Component {
   }
 }
 
-export default reduxForm({
-  form: 'course-reserves-terms'
-})(injectIntl(withStripes(TermSettings)));
+export default injectIntl(withStripes(TermSettings));


### PR DESCRIPTION
Noticed we could knock this one out fairly quickly, now that [`EditableList` supports redux-form and react-final-form](https://github.com/folio-org/stripes-smart-components/blob/e86c711c49033ad162ac7ac21b8fedda2d526257/lib/EditableList/EditableListFinalForm.js) and `ControlledVocab` lets us pass-through the `formType` into it.