### PR TITLE
use correct syntax (pursuant to STCOM-863)

### DIFF
--- a/src/components/Courses.css
+++ b/src/components/Courses.css
@@ -1,6 +1,6 @@
 @import "@folio/stripes-components/lib/variables";
 
-..searchControl {
+.searchControl {
   margin-left: -3px;
   margin-top: 8px;
   display: flex;


### PR DESCRIPTION
After the `postcss` changes in [STCOM-863](https://issues.folio.org/browse/STCOM-863) / [PR 1598](https://github.com/folio-org/stripes-components/pull/1598), 
we uncovered some previously unnoticed syntax errors.