### PR TITLE
UIPCIR-43: item-storage 10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Use local notes routes instead of pointing to `/users`. Refs UICR-161.
 * Remove react-hot-loader. Refs UICR-154.
+* Support interface `item-storage` `10.0`. Refs UIPCIR-43.
 
 ## [5.1.0](https://github.com/folio-org/ui-courses/tree/v5.1.0) (2022-03-02)
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
       "copyright-status-storage": "0.1",
       "role-storage": "0.1",
       "locations": "3.0",
-      "item-storage": "7.1 8.0 9.0",
+      "item-storage": "7.1 8.0 9.0 10.0",
       "loan-types": "2.2"
     },
     "permissionSets": [


### PR DESCRIPTION
mod-inventory-storage has new major interface versions:

instance-storage 9.0
holdings-storage 6.0
item-storage 10.0

ui-courses uses only item-storage, not the other two.

ui-courses is not affected because the incompatible change is in the DELETE all APIs only.

Only the okapiInterfaces need to be bumped in package.json.