### PR TITLE
UICR-150 - refactor psets away from backend ".all" permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Change history for ui-courses
+# In progress ...
+* refactor psets away from backend ".all" permissions. Refs UICR-150.
 
 ## [5.2.0](https://github.com/folio-org/ui-courses/tree/v5.2.0) (2022-09-07)
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,15 @@
           "ui-courses.maintain-courses",
           "ui-courses.maintain-items",
           "ui-courses.maintain-settings",
-          "course-reserves-storage.all"
+          "course-reserves-storage.terms.write",
+          "course-reserves-storage.courselistings.write",
+          "course-reserves-storage.roles.write",
+          "course-reserves-storage.departments.write",
+          "course-reserves-storage.course-types.write",
+          "course-reserves-storage.processing-statuses.write",
+          "course-reserves-storage.copyright-statuses.write",
+          "course-reserves-storage.courses.write",
+          "course-reserves-storage.reserves.write"
         ],
         "visible": true
       },


### PR DESCRIPTION
## Purpose
refactor psets away from backend ".all" permissions

## Refs
https://issues.folio.org/browse/UICR-150

