### PR TITLE
Unanchored filtering of candidate filter values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update `@folio/plugin-create-inventory-records` dependency version to one compatible with our Stripes version. Fixes UICR-169.
 * Move `prop-types` from dev-dependency to regular dependency. Fixes UICR-168.
 * Replace `babel-eslint` with `@babel/eslint-parser`. Fixes STRIPES-742.
+* Filtering of candidate values for location filter (and other search filters) is no longer left-anchored, but matches anywhere within the candidate values, emulating the behaviour of the Inventory app. Fixes UICR-160.
 
 ## [5.3.0](https://github.com/folio-org/ui-courses/tree/v5.3.0) (2022-10-25)
 

--- a/src/util/renderFilter.js
+++ b/src/util/renderFilter.js
@@ -3,8 +3,27 @@ import { FormattedMessage } from 'react-intl';
 import { Accordion, FilterAccordionHeader } from '@folio/stripes/components';
 import { MultiSelectionFilter } from '@folio/stripes/smart-components';
 
+
+// Copied from stripes-components/lib/MultiSelection/MultiSelection.js
+// The only change is the removal of left-anchoring from the regexp.
+// 
+const filterOptions = (filterText, list) => {
+  // escape special characters in filter text, so they won't be interpreted by RegExp
+  const escapedFilterText = filterText?.replace(/[#-.]|[[-^]|[?|{}]/g, '\\$&');
+
+  const filterRegExp = new RegExp(`${escapedFilterText}`, 'i');
+  const renderedItems = filterText ? list.filter(item => item.label.search(filterRegExp) !== -1) : list;
+  const exactMatch = filterText ? (renderedItems.filter(item => item.label === filterText).length === 1) : false;
+  return { renderedItems, exactMatch };
+};
+
+
 function renderFilter(filterHandlers, activeFilters, options, name, translationId, dataName) {
   const values = activeFilters[name] || [];
+
+  function filterCandidateValues(s, candidates, c, d) {
+    return candidates;
+  }
 
   return (
     <Accordion
@@ -22,6 +41,7 @@ function renderFilter(filterHandlers, activeFilters, options, name, translationI
         dataOptions={options[dataName || name]}
         selectedValues={values}
         onChange={(group) => filterHandlers.state({ ...activeFilters, [group.name]: group.values })}
+        filter={filterOptions}
       />
     </Accordion>
   );


### PR DESCRIPTION
Filtering of candidate values for location filter (and other search filters) is no longer left-anchored, but matches anywhere within the candidate values, emulating the behaviour of the Inventory app.

Fixes UICR-160.