### PR TITLE
UICR-189: Hide pop-up check box options while editing a note.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-courses
 
+## [6.1.0] IN PROGRESS
+
+* Hide pop-up check box options while editing a note. Fixes UICR-189.
+
 ## [6.0.2](https://github.com/folio-org/ui-courses/tree/v6.0.2) (2023-10-13)
 
 * Bump `@folio/plugin-create-inventory-records` version.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/courses",
-  "version": "6.0.2",
+  "version": "6.1.0",
   "description": "Maintain courses and reserve items for them",
   "repository": "https://github.com/folio-org/ui-courses",
   "license": "Apache-2.0",

--- a/src/routes/NoteEditRoute.js
+++ b/src/routes/NoteEditRoute.js
@@ -35,7 +35,7 @@ const NoteEditRoute = () => {
       domain="courses"
       navigateBack={navigateBack}
       noteId={noteId}
-      showDisplayAsPopupOptions
+      showDisplayAsPopupOptions={false}
     />
   );
 };


### PR DESCRIPTION
## Purpose
Hide pop-up check box options while editing a note.
## Issues
[UICR-189](https://issues.folio.org/browse/UICR-189)
## Screenshots
![image](https://github.com/folio-org/ui-courses/assets/77053927/f3ef0a9e-0b3f-4a0b-ab81-0448b69574ba)

