### PR TITLE
UICR-202 PropTypes fixup

### DIFF
--- a/src/components/CourseForm/CourseForm.js
+++ b/src/components/CourseForm/CourseForm.js
@@ -30,7 +30,7 @@ import { handleKeyCommand } from '../../util/handleKeyCommand';
 class CourseForm extends React.Component {
   static propTypes = {
     data: PropTypes.object,
-    handlers: PropTypes.PropTypes.shape({
+    handlers: PropTypes.shape({
       onClose: PropTypes.func.isRequired,
     }),
     handleSubmit: PropTypes.func.isRequired,

--- a/src/components/InstructorForm.js
+++ b/src/components/InstructorForm.js
@@ -24,7 +24,7 @@ import LoadingPaneSet from './LoadingPaneSet';
 class InstructorForm extends React.Component {
   static propTypes = {
     data: PropTypes.object,
-    handlers: PropTypes.PropTypes.shape({
+    handlers: PropTypes.shape({
       onClose: PropTypes.func.isRequired,
     }),
     handleSubmit: PropTypes.func.isRequired,

--- a/src/components/ReserveForm/ReserveForm.js
+++ b/src/components/ReserveForm/ReserveForm.js
@@ -24,7 +24,7 @@ import { handleKeyCommand } from '../../util/handleKeyCommand';
 class ReserveForm extends React.Component {
   static propTypes = {
     data: PropTypes.object,
-    handlers: PropTypes.PropTypes.shape({
+    handlers: PropTypes.shape({
       onClose: PropTypes.func.isRequired,
     }),
     handleSubmit: PropTypes.func.isRequired,


### PR DESCRIPTION
Use `PropTypes.shape`, which is a thing, instead of `PropTypes.PropTypes.shape`, which is not. Interestingly, neither yarn nor lint tripped on this, but experimenting with pnpm it showed up immediately as an unrecoverable error.

Refs [UICR-202](https://folio-org.atlassian.net/browse/UICR-202)