### PR TITLE
When deleting a course, also delete its courselisting 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [6.1.0] IN PROGRESS
 
+* When deleting a course, try to also delete its underlying courselisting. This ensures orphan courselistings are not created. Fixes UICR-206.
+
 ## [6.0.3](https://github.com/folio-org/ui-courses/tree/v6.0.3) (2023-10-20)
 
 * Hide pop-up check box options while editing a note. Fixes UICR-189.

--- a/src/components/CourseForm/CourseForm.js
+++ b/src/components/CourseForm/CourseForm.js
@@ -114,7 +114,7 @@ class CourseForm extends React.Component {
                       buttonStyle="danger mega"
                       id="clickable-really-delete-course"
                       marginBottom0
-                      onClick={handleDelete}
+                      onClick={() => handleDelete(values)}
                     >
                       <FormattedMessage id="ui-courses.reallyDelete" />
                     </Button>

--- a/src/routes/EditCourseRoute.js
+++ b/src/routes/EditCourseRoute.js
@@ -25,6 +25,9 @@ class EditCourseRoute extends React.Component {
         const rec = get(resources, 'course.records.0');
         return !rec ? null : `coursereserves/courselistings/${rec.courseListingId}`;
       },
+      DELETE: {
+        throwErrors: false,
+      },
     },
     allCoursesInListing: {
       type: 'okapi',
@@ -116,7 +119,19 @@ class EditCourseRoute extends React.Component {
     const { location } = this.props;
 
     this.props.mutator.course.DELETE({})
-      .then(() => this.props.mutator.courselisting.DELETE(listing))
+      .then(() => {
+        try {
+          // Clean up the courselisting to avoid leaving orphans
+          this.props.mutator.courselisting.DELETE(listing);
+        } catch (e) {
+          // Probably because the courselisting has other courses
+          // Nothing to be done here
+          //
+          // TODO I don't understand why this console.log and alert do not fire
+          console.log('delete courselisting failed:', e); // eslint-disable-line no-console
+          alert('delete courselisting failed:', e); // eslint-disable-line no-alert
+        }
+      })
       .then(this.props.history.push(`/cr/courses${location.search}`));
   }
 

--- a/src/routes/EditCourseRoute.js
+++ b/src/routes/EditCourseRoute.js
@@ -68,6 +68,7 @@ class EditCourseRoute extends React.Component {
       }).isRequired,
       courselisting: PropTypes.shape({
         PUT: PropTypes.func.isRequired,
+        DELETE: PropTypes.func.isRequired,
       }).isRequired,
     }).isRequired,
     stripes: PropTypes.shape({
@@ -110,9 +111,12 @@ class EditCourseRoute extends React.Component {
       .then(this.handleClose);
   }
 
-  handleDelete = () => {
+  handleDelete = (data) => {
+    const listing = data.courseListingObject;
     const { location } = this.props;
+
     this.props.mutator.course.DELETE({})
+      .then(() => this.props.mutator.courselisting.DELETE(listing))
       .then(this.props.history.push(`/cr/courses${location.search}`));
   }
 


### PR DESCRIPTION
This is intended to prevent orphan course-listings from lying around, preventing the deletion of terms that are still in use by them (see UICR-203). If the deletion of course-listing fails, we ignore that failure, as it's likely due to the existence of another course using it.

This works so far as it goes, but it turns out that course-listing deletion also fails if there are instructors assigned, and that these need to be deleted first. Since I'm not sure whether that ought to be the UI's responsibility, I'm ignoring it for now and committing the present version.

Fixes UICR-206.
