### PR TITLE
[UICR-222] Update plugin dependencies for Sunflower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-courses
 
+## [7.0.1](https://github.com/folio-org/ui-courses/tree/v7.0.1) (IN PROGRESS)
+
+* Update plugin dependencies to allow `@folio/plugin-find-user` ^8.0.0 and `@folio/plugin-create-inventory-records` ^6.0.0 (as well as previously acceptable versions). Fixes UICR-222.
+
 ## [7.0.0](https://github.com/folio-org/ui-courses/tree/v7.0.0) (2025-03-11)
 
 * **BREAKING**: upgrade to Stripes v10. Fixes UICR-216.

--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
     "react-final-form": "^6.3.0"
   },
   "peerDependencies": {
-    "@folio/plugin-find-user": "^5.0.0||^6.0.0||^7.0.0",
+    "@folio/plugin-find-user": "^5.0.0||^6.0.0||^7.0.0||^8.0.0",
     "@folio/stripes": "^10.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -255,6 +255,6 @@
     "yakbak-proxy": "^1.6.0"
   },
   "optionalDependencies": {
-    "@folio/plugin-create-inventory-records": "^4.0.0||^5.0.0"
+    "@folio/plugin-create-inventory-records": "^4.0.0||^5.0.0||^6.0.0"
   }
 }


### PR DESCRIPTION
Update plugin dependencies to allow
* `@folio/plugin-find-user` ^8.0.0
* `@folio/plugin-create-inventory-records` ^6.0.0

(as well as previously acceptable versions).