### PR TITLE
[UICR-225] Sort even when query is not specified.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-courses
 
+## [7.0.3](https://github.com/folio-org/ui-courses/tree/v7.0.3) (IN PROGRESS)
+
+* Since release v6.1.1, when listing all courses or reserves (as opposed to those matching a query), sorting was not performed. This is no longer the case. Fixes UICR-225.
+
 ## [7.0.2](https://github.com/folio-org/ui-courses/tree/v7.0.2) (2025-03-27)
 
 * When displaying details of a course, loading the reserves now forces the items to load. This fixes a race condition. Previously, the two loads would nearly always, but not always, happen in the right order; but sometimes the attempt to load items would happen first, and there would be no item-IDs available to search for. This was most easily seen by refreshing the whole app. Fixes UICR-221.

--- a/src/routes/CoursesRoute.js
+++ b/src/routes/CoursesRoute.js
@@ -71,9 +71,8 @@ class CoursesRoute extends React.Component {
       path: 'coursereserves/courses',
       params: {
         query: (qp, pathComponents, rv, logger) => {
-          if (qp.query === undefined) return undefined;
           // Is it not a strange fate that we should suffer so much fear and doubt for so small a thing?
-          const qq = qp.query.replace(/\*+$/, '');
+          const qq = (qp.query === undefined) ? undefined : qp.query.replace(/\*+$/, '');
           const queryFunction = makeQueryFunction(
             'cql.allRecords=1',
             searchableIndexes.map(index => `${index}="${qq}*"`).join(' or '),

--- a/src/routes/ReservesRoute.js
+++ b/src/routes/ReservesRoute.js
@@ -70,9 +70,8 @@ class ReservesRoute extends React.Component {
       path: 'coursereserves/reserves',
       params: {
         query: (qp, pathComponents, rv, logger) => {
-          if (qp.query === undefined) return undefined;
           // Is it not a strange fate that we should suffer so much fear and doubt for so small a thing?
-          const qq = qp.query.replace(/\*+$/, '');
+          const qq = (qp.query === undefined) ? undefined : qp.query.replace(/\*+$/, '');
           const queryFunction = makeQueryFunction(
             'cql.allRecords=1',
             searchableIndexes.map(index => `${index}="${qq}*"`).join(' or '),


### PR DESCRIPTION
Since release v6.1.1, when listing all courses or reserves (as opposed to those matching a query), sorting was not performed. This is no longer the case.