### PR TITLE
[UICR-195] Omit nonfunctional "Add" buttons in settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-courses
 
+## [7.0.4](https://github.com/folio-org/ui-courses/tree/v7.0.4) (IN PROGRESS)
+
+* When a user has the permission `ui-courses.view-settings` ("Settings (Courses): Can view course settings") but not `ui-courses.maintain-settings` ("Settings (Courses): Can create, edit and delete course settings"), the **New** button is no longer displayed at the top of the settings pages for Terms, Course types, Course departments, Processing statuses and Copryright types. Fixes UICR-195.
+
 ## [7.0.3](https://github.com/folio-org/ui-courses/tree/v7.0.3) (2025-03-31)
 
 * Since release v6.1.1, when listing all courses or reserves (as opposed to those matching a query), sorting was not performed. This is no longer the case. Fixes UICR-225.

--- a/src/settings/CopyrightStatusSettings.js
+++ b/src/settings/CopyrightStatusSettings.js
@@ -47,6 +47,7 @@ class CopyrightStatusSettings extends React.Component {
         id="copyrightstatuses"
         sortby="name"
         hiddenFields={['lastUpdated', 'numberOfObjects']}
+        canCreate={stripes.hasPerm('course-reserves-storage.copyright-statuses.item.post')}
         actionSuppressor={{
           edit: () => !stripes.hasPerm('course-reserves-storage.copyright-statuses.item.put'),
           'delete': () => !stripes.hasPerm('course-reserves-storage.copyright-statuses.item.delete'),

--- a/src/settings/CourseTypeSettings.js
+++ b/src/settings/CourseTypeSettings.js
@@ -47,6 +47,7 @@ class CourseTypeSettings extends React.Component {
         id="coursetypes"
         sortby="name"
         hiddenFields={['lastUpdated', 'numberOfObjects']}
+        canCreate={stripes.hasPerm('course-reserves-storage.course-types.item.post')}
         actionSuppressor={{
           edit: () => !stripes.hasPerm('course-reserves-storage.course-types.item.put'),
           'delete': () => !stripes.hasPerm('course-reserves-storage.course-types.item.delete'),

--- a/src/settings/DepartmentSettings.js
+++ b/src/settings/DepartmentSettings.js
@@ -47,6 +47,7 @@ class DepartmentSettings extends React.Component {
         id="departments"
         sortby="name"
         hiddenFields={['lastUpdated', 'numberOfObjects']}
+        canCreate={stripes.hasPerm('course-reserves-storage.departments.item.post')}
         actionSuppressor={{
           edit: () => !stripes.hasPerm('course-reserves-storage.departments.item.put'),
           'delete': () => !stripes.hasPerm('course-reserves-storage.departments.item.delete'),

--- a/src/settings/ProcessingStatusSettings.js
+++ b/src/settings/ProcessingStatusSettings.js
@@ -47,6 +47,7 @@ class ProcessingStatusSettings extends React.Component {
         id="processingstatuses"
         sortby="name"
         hiddenFields={['lastUpdated', 'numberOfObjects']}
+        canCreate={stripes.hasPerm('course-reserves-storage.processing-statuses.item.post')}
         actionSuppressor={{
           edit: () => !stripes.hasPerm('course-reserves-storage.processing-statuses.item.put'),
           'delete': () => !stripes.hasPerm('course-reserves-storage.processing-statuses.item.delete'),

--- a/src/settings/TermSettings.js
+++ b/src/settings/TermSettings.js
@@ -74,6 +74,7 @@ class TermSettings extends React.Component {
         id="terms"
         sortby="name"
         hiddenFields={['lastUpdated', 'numberOfObjects']}
+        canCreate={stripes.hasPerm('course-reserves-storage.terms.item.post')}
         actionSuppressor={{
           edit: () => !stripes.hasPerm('course-reserves-storage.terms.item.put'),
           'delete': () => !stripes.hasPerm('course-reserves-storage.terms.item.delete'),


### PR DESCRIPTION
When a user has the permission `ui-courses.view-settings` ("Settings (Courses): Can view course settings") but not
`ui-courses.maintain-settings` ("Settings (Courses): Can create, edit and delete course settings"), the **New** button is no longer displayed at the top of the settings pages for Terms, Course types, Course departments, Processing statuses and Copryright types.

(Previously the button was displayed, and it was possible to enter the details of a new object -- but of course the actual creation of the object failed, rightly.)