### PR TITLE
[UICR-184] Do not link to non-existent course on a bad URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [7.0.4](https://github.com/folio-org/ui-courses/tree/v7.0.4) (IN PROGRESS)
 
 * When a user has the permission `ui-courses.view-settings` ("Settings (Courses): Can view course settings") but not `ui-courses.maintain-settings` ("Settings (Courses): Can create, edit and delete course settings"), the **New** button is no longer displayed at the top of the settings pages for Terms, Course types, Course departments, Processing statuses and Copryright types. Fixes UICR-195.
+* When a user clicks on a malformed "URL/PDF link" field, do not try to display a non-existent course. Fixes UICR-184.
 
 ## [7.0.3](https://github.com/folio-org/ui-courses/tree/v7.0.3) (2025-03-31)
 

--- a/src/components/ViewCourse/sections/ViewCourseReserves.js
+++ b/src/components/ViewCourse/sections/ViewCourseReserves.js
@@ -60,7 +60,11 @@ function makeContentLink(eaList) {
   const ea = (eaList || [])[0];
   if (!ea || !ea.uri) return null;
   const text = ea.linkText || <FormattedMessage id="ui-courses.link" />;
-  return <a rel="noopener noreferrer" target="_blank" href={ea.uri} title={ea.publicNote}>{text}</a>;
+  let uri = ea.uri;
+  if (!uri.match('^[a-z]+:')) {
+    uri = 'https://' + uri;
+  }
+  return <a rel="noopener noreferrer" target="_blank" href={uri} title={ea.publicNote}>{text}</a>;
 }
 
 


### PR DESCRIPTION
When a user clicks on a malformed "URL/PDF link" field (usually one with no scheme specified), we previously allowed the browser to go ahead and treat it as a relative URL, resulting in trying to displaying a course whose ID is the malformed URL. We now catch such cases and guess that the links were meant to be HTTPS.