### PR TITLE
[UICR-235] ui-courses.add-edit-items permission now contains users.collection.get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * When a user clicks on a malformed "URL/PDF link" field, do not try to display a non-existent course. Fixes UICR-184.
 * Fix `en.json` translations for maintenance of terms in settings. Fixes UICR-229.
 * Support interface `item-storage` `11.0`. Refs UICR-231.
+* `ui-courses.add-edit-items` permission now contains `users.collection.get`. This allows the last-edited metadata header to be displayed when editing a course reserve. Fixes UICR-235.
 
 ## [7.0.3](https://github.com/folio-org/ui-courses/tree/v7.0.3) (2025-03-31)
 

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-{
+git{
   "name": "@folio/courses",
   "version": "7.0.3",
   "description": "Maintain courses and reserve items for them",
@@ -9,6 +9,7 @@
     "test-folio-snapshot": "cypress run --config baseUrl=https://folio-snapshot.dev.folio.org",
     "start": "stripes serve --port 3001",
     "start2": "stripes serve --start-proxy --port 3011 --okapi https://indexdata-test-okapi.folio.indexdata.com --tenant indexdata",
+    "start3": "stripes serve --port 3012 --okapi https://folio-snapshot-okapi.dev.folio.org --tenant diku",
     "test-running-service": "cypress run",
     "test-new-ui": "stripes serve --okapi https://folio-snapshot-okapi.dev.folio.org --port 3001 & wait-on http://localhost:3001 && cypress run; kill $!",
     "test": "stripes serve --coverage --port 3001 --okapi http://localhost:3002 & pid1=$! && env LOGCAT=startup yakbak-proxy -i -x -n & pid2=$! && wait-on http://localhost:3001 && cypress run; kill $pid1 $pid2",
@@ -161,7 +162,8 @@
           "inventory-storage.loan-types.collection.get",
           "inventory-storage.loan-types.item.get",
           "inventory-storage.items.item.get",
-          "inventory-storage.items.item.put"
+          "inventory-storage.items.item.put",
+	  "users.collection.get"
         ],
         "visible": true
       },

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-git{
+{
   "name": "@folio/courses",
   "version": "7.0.3",
   "description": "Maintain courses and reserve items for them",


### PR DESCRIPTION
This allows the last-edited metadata header to be displayed when editing a course reserve.